### PR TITLE
Indexing of messages.timestamp to avoid runtime-copy.

### DIFF
--- a/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
+++ b/rosbag2_storage_default_plugins/src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp
@@ -135,18 +135,20 @@ std::vector<rosbag2_storage::TopicMetadata> SqliteStorage::get_all_topics_and_ty
 
 void SqliteStorage::initialize()
 {
-  std::string create_table = "CREATE TABLE topics(" \
+  std::string create_stmt = "CREATE TABLE topics(" \
     "id INTEGER PRIMARY KEY," \
     "name TEXT NOT NULL," \
     "type TEXT NOT NULL," \
     "serialization_format TEXT NOT NULL);";
-  database_->prepare_statement(create_table)->execute_and_reset();
-  create_table = "CREATE TABLE messages(" \
+  database_->prepare_statement(create_stmt)->execute_and_reset();
+  create_stmt = "CREATE TABLE messages(" \
     "id INTEGER PRIMARY KEY," \
     "topic_id INTEGER NOT NULL," \
     "timestamp INTEGER NOT NULL, " \
     "data BLOB NOT NULL);";
-  database_->prepare_statement(create_table)->execute_and_reset();
+  database_->prepare_statement(create_stmt)->execute_and_reset();
+  create_stmt = "CREATE INDEX timestamp_idx ON messages (timestamp ASC);";
+  database_->prepare_statement(create_stmt)->execute_and_reset();
 }
 
 void SqliteStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)


### PR DESCRIPTION
Extended SqliteStorage::initialize() to add an index for the message table's timestamp column.
Without this, the ORDER BY query in prepare_for_reading() causes expensive table duplication,
which also has potential for out-of-disk or out-of-memory issues.